### PR TITLE
Use realpath to allow symlinking to executable

### DIFF
--- a/bin/wolfman
+++ b/bin/wolfman
@@ -3,7 +3,8 @@
 # Need to add lib to load path, so that wolfman can be executed from other
 # directories with other ruby versions.
 require 'pathname'
-lib_directory = File.join(Pathname.new(__FILE__).dirname.parent, 'lib')
+parent_directory = Pathname.new(__FILE__).realpath.dirname.parent
+lib_directory = File.join(parent_directory, 'lib')
 $LOAD_PATH.unshift(lib_directory)
 
 require "wolfman"


### PR DESCRIPTION
I have a local  ~/.bin folder where i symlink various scripts and binaries...

Sadly it's not finding the correct parent path.